### PR TITLE
Suppress line length warning

### DIFF
--- a/molecule/docker/molecule.yml
+++ b/molecule/docker/molecule.yml
@@ -15,7 +15,7 @@ provisioner:
     name: ansible-lint
     options:
       x:
-        - "204"
+        - "204"  # Line-length checking, which yamllint already does
   playbooks:
     prepare: ../shared/prepare.yml
     converge: ../shared/playbook.yml

--- a/molecule/docker/molecule.yml
+++ b/molecule/docker/molecule.yml
@@ -13,6 +13,9 @@ provisioner:
   name: ansible
   lint:
     name: ansible-lint
+    options:
+      x:
+        - "204"
   playbooks:
     prepare: ../shared/prepare.yml
     converge: ../shared/playbook.yml

--- a/molecule/openstack/molecule.yml
+++ b/molecule/openstack/molecule.yml
@@ -16,7 +16,7 @@ provisioner:
     name: ansible-lint
     options:
       x:
-        - "204"
+        - "204"  # Line-length checking, which yamllint already does
   playbooks:
     prepare: ../shared/prepare.yml
     converge: ../shared/playbook.yml

--- a/molecule/openstack/molecule.yml
+++ b/molecule/openstack/molecule.yml
@@ -14,6 +14,9 @@ provisioner:
   name: ansible
   lint:
     name: ansible-lint
+    options:
+      x:
+        - "204"
   playbooks:
     prepare: ../shared/prepare.yml
     converge: ../shared/playbook.yml


### PR DESCRIPTION
Line length warnings from Ansible-lint duplicate those in yamllint, and
we are disabling it there for this particular line. Therefore, don't
have ansible-lint double check the line length for us